### PR TITLE
Avoid zoom on input fields in Safari iOS by setting the font-size to 16px

### DIFF
--- a/src/components/Data.vue
+++ b/src/components/Data.vue
@@ -227,4 +227,8 @@ export default {
   }
 }
 
+input.form-control {
+  font-size: 16px;
+}
+
 </style>


### PR DESCRIPTION
Hi,

I found your website recently, it's a handy tool to check download statistics

When clicking on the text field to enter the username or repo name in Safari on iOS, the browser zooms in because the input is using a smaller font size by default
![Image 1](https://user-images.githubusercontent.com/14317886/146084651-81f00577-12c6-4192-95fe-3d66ea528702.png)

This pull requests sets the font size to 16px to avoid the zooming
![Image 2](https://user-images.githubusercontent.com/14317886/146084674-b6dfa961-b2f1-4a9e-9442-54dd61e6bc65.png)
